### PR TITLE
Split COPY stmts and fix invalid s3 hostname exceptions w old aws-java-sdk

### DIFF
--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -70,9 +70,7 @@ object SparkRedshiftBuild extends Build {
         // conflicts for a majority of users while adding a minor inconvienece (adding one extra
         // depenendecy by hand) for a smaller set of users.
         // We exclude jackson-databind to avoid a conflict with Spark's version (see #104).
-        "com.amazonaws" % "aws-java-sdk-core" % "1.10.22" % "provided" exclude("com.fasterxml.jackson.core", "jackson-databind"),
-        "com.amazonaws" % "aws-java-sdk-s3" % "1.10.22" % "provided" exclude("com.fasterxml.jackson.core", "jackson-databind"),
-        "com.amazonaws" % "aws-java-sdk-sts" % "1.10.22" % "test" exclude("com.fasterxml.jackson.core", "jackson-databind"),
+        "com.amazonaws" % "aws-java-sdk" % "1.7.4" % "provided" exclude("com.fasterxml.jackson.core", "jackson-databind"),
         // We require spark-avro, but avro-mapred must be provided to match Hadoop version.
         // In most cases, avro-mapred will be provided as part of the Spark assembly JAR.
         "com.databricks" %% "spark-avro" % "2.0.1",

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -70,7 +70,9 @@ object SparkRedshiftBuild extends Build {
         // conflicts for a majority of users while adding a minor inconvienece (adding one extra
         // depenendecy by hand) for a smaller set of users.
         // We exclude jackson-databind to avoid a conflict with Spark's version (see #104).
-        "com.amazonaws" % "aws-java-sdk" % "1.7.4" % "provided" exclude("com.fasterxml.jackson.core", "jackson-databind"),
+        "com.amazonaws" % "aws-java-sdk-core" % "1.10.22" % "provided" exclude("com.fasterxml.jackson.core", "jackson-databind"),
+        "com.amazonaws" % "aws-java-sdk-s3" % "1.10.22" % "provided" exclude("com.fasterxml.jackson.core", "jackson-databind"),
+        "com.amazonaws" % "aws-java-sdk-sts" % "1.10.22" % "test" exclude("com.fasterxml.jackson.core", "jackson-databind"),
         // We require spark-avro, but avro-mapred must be provided to match Hadoop version.
         // In most cases, avro-mapred will be provided as part of the Spark assembly JAR.
         "com.databricks" %% "spark-avro" % "2.0.1",

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -102,6 +102,9 @@ private[redshift] class RedshiftWriter(
       s"AVRO 'auto' manifest ${params.extraCopyOptions}"
   }
 
+  /**
+   * Generate the COPY SQL command for a single manifest entry url
+   */
   private def copyEntryUrlSql(
       sqlContext: SQLContext,
       params: MergedParameters,
@@ -184,7 +187,7 @@ private[redshift] class RedshiftWriter(
       // Read the MANIFEST file to get the list of S3 part files that were written by Redshift.
       // And load each entry individually
       log.warn("Using manifest url: " + manifestUrl)
-      val s3URI = new AmazonS3URI(Utils.fixS3Url(manifestUrl))
+      val s3URI = new AmazonS3URI(Utils.addEndpointToUrl(manifestUrl))
       val s3Client = s3ClientFactory(creds)
       val is = s3Client.getObject(s3URI.getBucket, s3URI.getKey).getObjectContent
 

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -16,24 +16,25 @@
 
 package com.databricks.spark.redshift
 
+import java.io.InputStreamReader
 import java.net.URI
 import java.sql.{Connection, Date, SQLException, Timestamp}
 
 import com.amazonaws.auth.AWSCredentials
-import com.amazonaws.services.s3.AmazonS3Client
-import org.apache.hadoop.fs.{Path, FileSystem}
+import com.amazonaws.services.s3.{AmazonS3Client, AmazonS3URI}
+import com.databricks.spark.redshift.Parameters.MergedParameters
+import com.eclipsesource.json.Json
+import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.TaskContext
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, Row, SQLContext, SaveMode}
 import org.slf4j.LoggerFactory
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.Random
 import scala.util.control.NonFatal
-
-import com.databricks.spark.redshift.Parameters.MergedParameters
-
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, Row, SaveMode, SQLContext}
-import org.apache.spark.sql.types._
 
 /**
  * Functions to write data to Redshift.
@@ -99,6 +100,17 @@ private[redshift] class RedshiftWriter(
     val fixedUrl = Utils.fixS3Url(manifestUrl)
     s"COPY ${params.table.get} FROM '$fixedUrl' CREDENTIALS '$credsString' FORMAT AS " +
       s"AVRO 'auto' manifest ${params.extraCopyOptions}"
+  }
+
+  private def copyEntryUrlSql(
+      sqlContext: SQLContext,
+      params: MergedParameters,
+      creds: AWSCredentials,
+      manifestEntryUrl: String): String = {
+    val credsString: String = AWSCredentialsUtils.getRedshiftCredentialsString(creds)
+    val fixedUrl = Utils.fixS3Url(manifestEntryUrl)
+    s"COPY ${params.table.get} FROM '$fixedUrl' CREDENTIALS '$credsString' FORMAT AS " +
+      s"AVRO 'auto' ${params.extraCopyOptions}"
   }
 
   /**
@@ -169,51 +181,69 @@ private[redshift] class RedshiftWriter(
     }
 
     manifestUrl.foreach { manifestUrl =>
-      // Load the temporary data into the new file
-      val copyStatement = copySql(data.sqlContext, params, creds, manifestUrl)
-      try {
-        jdbcWrapper.executeInterruptibly(conn.prepareStatement(copyStatement))
-      } catch {
-        case e: SQLException =>
-          // Try to query Redshift's STL_LOAD_ERRORS table to figure out why the load failed.
-          // See http://docs.aws.amazon.com/redshift/latest/dg/r_STL_LOAD_ERRORS.html for details.
-          val errorLookupQuery =
-            """
-              | SELECT *
-              | FROM stl_load_errors
-              | WHERE query = pg_last_query_id()
-            """.stripMargin
-          val detailedException: Option[SQLException] = try {
-            val results =
-              jdbcWrapper.executeQueryInterruptibly(conn.prepareStatement(errorLookupQuery))
-            if (results.next()) {
-              val errCode = results.getInt("err_code")
-              val errReason = results.getString("err_reason").trim
-              val columnLength: String =
-                Option(results.getString("col_length"))
-                  .map(_.trim)
-                  .filter(_.nonEmpty)
-                  .map(n => s"($n)")
-                  .getOrElse("")
-              val exceptionMessage =
-                s"""
-                   |Error (code $errCode) while loading data into Redshift: "$errReason"
-                   |Table name: ${params.table.get}
-                   |Column name: ${results.getString("colname").trim}
-                   |Column type: ${results.getString("type").trim}$columnLength
-                   |Raw line: ${results.getString("raw_line")}
-                   |Raw field value: ${results.getString("raw_field_value")}
+      // Read the MANIFEST file to get the list of S3 part files that were written by Redshift.
+      // And load each entry individually
+      log.warn("Using manifest url: " + manifestUrl)
+      val s3URI = new AmazonS3URI(Utils.fixS3Url(manifestUrl))
+      val s3Client = s3ClientFactory(creds)
+      val is = s3Client.getObject(s3URI.getBucket, s3URI.getKey).getObjectContent
+
+      val s3Files = try {
+        val entries = Json.parse(new InputStreamReader(is)).asObject().get("entries").asArray()
+        entries.iterator().asScala.map(_.asObject().get("url").asString()).toSeq
+      } finally {
+        is.close()
+      }
+
+      s3Files.foreach { entryUrl =>
+
+        // Load the temporary data into the new file
+        val copyStatement = copyEntryUrlSql(data.sqlContext, params, creds, entryUrl)
+        log.warn("Execute copy SQL Statement: " + copyStatement)
+        try {
+          jdbcWrapper.executeInterruptibly(conn.prepareStatement(copyStatement))
+        } catch {
+          case e: SQLException =>
+            // Try to query Redshift's STL_LOAD_ERRORS table to figure out why the load failed.
+            // See http://docs.aws.amazon.com/redshift/latest/dg/r_STL_LOAD_ERRORS.html for details.
+            val errorLookupQuery =
+              """
+                | SELECT *
+                | FROM stl_load_errors
+                | WHERE query = pg_last_query_id()
+              """.stripMargin
+            val detailedException: Option[SQLException] = try {
+              val results =
+                jdbcWrapper.executeQueryInterruptibly(conn.prepareStatement(errorLookupQuery))
+              if (results.next()) {
+                val errCode = results.getInt("err_code")
+                val errReason = results.getString("err_reason").trim
+                val columnLength: String =
+                  Option(results.getString("col_length"))
+                    .map(_.trim)
+                    .filter(_.nonEmpty)
+                    .map(n => s"($n)")
+                    .getOrElse("")
+                val exceptionMessage =
+                  s"""
+                     |Error (code $errCode) while loading data into Redshift: "$errReason"
+                     |Table name: ${params.table.get}
+                     |Column name: ${results.getString("colname").trim}
+                     |Column type: ${results.getString("type").trim}$columnLength
+                     |Raw line: ${results.getString("raw_line")}
+                     |Raw field value: ${results.getString("raw_field_value")}
                   """.stripMargin
-              Some(new SQLException(exceptionMessage, e))
-            } else {
-              None
+                Some(new SQLException(exceptionMessage, e))
+              } else {
+                None
+              }
+            } catch {
+              case NonFatal(e2) =>
+                log.error("Error occurred while querying STL_LOAD_ERRORS", e2)
+                None
             }
-          } catch {
-            case NonFatal(e2) =>
-              log.error("Error occurred while querying STL_LOAD_ERRORS", e2)
-              None
-          }
-          throw detailedException.getOrElse(e)
+            throw detailedException.getOrElse(e)
+        }
       }
     }
 

--- a/src/main/scala/com/databricks/spark/redshift/Utils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Utils.scala
@@ -56,6 +56,14 @@ private[redshift] object Utils {
    * for data loads. This function converts the URL back to the s3:// format.
    */
   def fixS3Url(url: String): String = {
+    url.replaceAll("s3[an]://", "s3://")
+  }
+
+  /**
+   * Since older AWS Java Libraries do not handle S3 urls that have just the bucket name
+   * as the host, add the endpoint to the host
+   */
+  def addEndpointToUrl(url: String): String = {
     var fixUrl = url
     fixUrl = url.replaceAll("s3[an]://", "s3://")
 

--- a/src/test/scala/com/databricks/spark/redshift/AWSCredentialsUtilsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/AWSCredentialsUtilsSuite.scala
@@ -16,6 +16,8 @@
 
 package com.databricks.spark.redshift
 
+import com.amazonaws.services.s3.AmazonS3URI
+
 import scala.language.implicitConversions
 
 import com.amazonaws.AmazonClientException

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -138,6 +138,7 @@ class RedshiftSourceSuite
       }
     }
     when(mockS3Client.getObject(anyString(), endsWith("manifest"))).thenReturn(mockManifest)
+    when(mockS3Client.getObject(anyString(), endsWith("manifest.json"))).thenReturn(mockManifest)
   }
 
   override def afterEach(): Unit = {

--- a/src/test/scala/com/databricks/spark/redshift/UtilsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/UtilsSuite.scala
@@ -40,8 +40,8 @@ class UtilsSuite extends FunSuite with Matchers {
   }
 
   test("fixUrl produces Redshift-compatible equivalents") {
-    Utils.fixS3Url("s3a://foo/bar/12345") shouldBe "s3://foo/bar/12345"
-    Utils.fixS3Url("s3n://foo/bar/baz") shouldBe "s3://foo/bar/baz"
+    Utils.fixS3Url("s3a://foo/bar/12345") shouldBe "s3://foo.s3.amazonaws.com/bar/12345"
+    Utils.fixS3Url("s3n://foo/bar/baz") shouldBe "s3://foo.s3.amazonaws.com/bar/baz"
   }
 
   test("temp paths are random subdirectories of root") {

--- a/src/test/scala/com/databricks/spark/redshift/UtilsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/UtilsSuite.scala
@@ -40,8 +40,13 @@ class UtilsSuite extends FunSuite with Matchers {
   }
 
   test("fixUrl produces Redshift-compatible equivalents") {
-    Utils.fixS3Url("s3a://foo/bar/12345") shouldBe "s3://foo.s3.amazonaws.com/bar/12345"
-    Utils.fixS3Url("s3n://foo/bar/baz") shouldBe "s3://foo.s3.amazonaws.com/bar/baz"
+    Utils.fixS3Url("s3a://foo/bar/12345") shouldBe "s3://foo/bar/12345"
+    Utils.fixS3Url("s3n://foo/bar/baz") shouldBe "s3://foo/bar/baz"
+  }
+
+  test("addEndpointToUrl produces urls with endpoints added to host") {
+    Utils.addEndpointToUrl("s3a://foo/bar/12345") shouldBe "s3://foo.s3.amazonaws.com/bar/12345"
+    Utils.addEndpointToUrl("s3n://foo/bar/baz") shouldBe "s3://foo.s3.amazonaws.com/bar/baz"
   }
 
   test("temp paths are random subdirectories of root") {


### PR DESCRIPTION
There were two major problems with the spark-redshift library.

1) Only a single copy statement gets executed.  When we do a large COPY we will always hit the timeout limits.  As such, take apart the manifest.json and for each entry, execute a separate copy statement.
2) We see an "Invalid hostname" exception when using the aws-java-sdk 1.7.4 library.  As such attach the default endpoint if none is specified.  Also it's important to note that we can't use a newer aws-java-sdk library just yet as we will run into https://issues.apache.org/jira/browse/HADOOP-12420 when using hadoop-aws 2.7.1.

Please review @keeyonghan @sungjuly @nsullins @Matttiwari 
